### PR TITLE
change how init proc is setup in entry point modules

### DIFF
--- a/extras/build_examples.sh
+++ b/extras/build_examples.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 declare -a modules=(
   cjkscroll
   cli1

--- a/notcurses.nim
+++ b/notcurses.nim
@@ -1,7 +1,15 @@
 {.passL: "-lnotcurses -lnotcurses-core".}
 
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  {.push raises: [].}
+else:
+  {.push raises: [Defect].}
+
+import ./notcurses/abi/impl as abi_impl
 import ./notcurses/api/impl
 
-export impl except setNcInit, setNcCoreInit
+export impl
 
-setNcInit()
+proc init*(T: type Notcurses, options = Options.init, file = stdout,
+    addExitProc = true): T =
+  T.init(notcurses_init, options, file, addExitProc)

--- a/notcurses/abi/wide.nim
+++ b/notcurses/abi/wide.nim
@@ -7,7 +7,6 @@ import std/[bitops, macros, typetraits]
 import pkg/stew/byteutils
 
 const
-  unexpected_base = "unexpected base type for Wchar"
   wchar_header = "<wchar.h>"
   wchar_t = "wchar_t"
 
@@ -35,7 +34,7 @@ func toSeqB*(ws: ptr UncheckedArray[Wchar]): seq[byte] =
   when not (DbW is cuint or DbW is cushort):
     # `when` branch was added for defining `type Wchar` but is not accounted
     # for in `toSeqB`
-    {.fatal: unexpectedBase & ": " & $distinctBase(Wchar).}
+    {.fatal: "unexpected base type for Wchar: " & $distinctBase(Wchar).}
   var
     c = DbW(0)
     codepoint = 0'u32
@@ -113,7 +112,7 @@ func toSeqW*(s: string): seq[Wchar] =
       else:
         # `when` branch was added for defining `type Wchar` but is not
         # accounted for in `toSeqW`
-        {.fatal: unexpectedBase & ": " & $distinctBase(Wchar).}
+        {.fatal: "unexpected base type for Wchar: " & $distinctBase(Wchar).}
   when nimvm:
     var wcs: seq[Wchar]
     for c in codes:

--- a/notcurses/api/direct/impl.nim
+++ b/notcurses/api/direct/impl.nim
@@ -21,7 +21,7 @@ type
     PutStr = "ncdirect_putstr failed"
     SetStyles = "ncdirect_set_styles failed"
 
-  InitProc = proc (t: cstring, f: File, flags: uint64): ptr ncdirect {.cdecl.}
+  InitProc = proc (termtype: cstring, fp: File, flags: uint64): ptr ncdirect {.cdecl.}
 
   NotcursesDirect* = object
     cPtr: ptr ncdirect
@@ -37,7 +37,6 @@ type
 var
   ncdApiObj {.threadvar.}: NotcursesDirect
   ncdExitProcAdded: Atomic[bool]
-  ncdInit: InitProc
   ncdPtr: Atomic[ptr ncdirect]
 
 proc get*(T: type NotcursesDirect): T =
@@ -59,22 +58,6 @@ proc putStr*(ncd: NotcursesDirect, s: string, channel = Channel(0)):
     err ApiErrorCode(code: code, msg: $PutStr)
   else:
     ok code
-
-proc setNcdInit*() =
-  if ncdInit.isNil: ncdInit = ncdirect_init
-  elif ncdInit != ncdirect_init:
-    let msg =
-      "cannot set init proc as ncdirect_init when it is already set as " &
-      "ncdirect_core_init"
-    raise (ref ApiDefect)(msg: msg)
-
-proc setNcdCoreInit*() =
-  if ncdInit.isNil: ncdInit = ncdirect_core_init
-  elif ncdInit != ncdirect_core_init:
-    let msg =
-      "cannot set init proc as ncdirect_core_init when it is already set as " &
-      "ncdirect_init"
-    raise (ref ApiDefect)(msg: msg)
 
 proc setStyles*(ncd: NotcursesDirect, styles: varargs[Styles]):
     Result[ApiSuccess, ApiErrorCode] =
@@ -106,17 +89,16 @@ else:
   template addExitProc(T: type NotcursesDirect) =
     if not ncdExitProcAdded.exchange(true): addQuitProc stopNotcurses
 
-proc init*(T: type NotcursesDirect, options = Options.init, file = stdout,
-    addExitProc = true): T =
+proc init*(T: type NotcursesDirect, initProc: InitProc, options = Options.init,
+    file = stdout, addExitProc = true): T =
   setNcdIniting()
-  if ncdInit.isNil: raise (ref Defect)(msg: $NotcursesDirectInitNotSet)
   var cPtr: ptr ncdirect
   var termtype: cstring
   if options.term != "": termtype = options.term.cstring
   when (NimMajor, NimMinor, NimPatch) > (1, 6, 10):
     {.warning[BareExcept]: off.}
   try:
-    cPtr = ncdInit(termtype, file, options.flags)
+    cPtr = initProc(termtype, file, options.flags)
   except Exception:
     raise (ref ApiDefect)(msg: $NotcursesDirectFailedToInitialize)
   when (NimMajor, NimMinor, NimPatch) > (1, 6, 10):

--- a/notcurses/core.nim
+++ b/notcurses/core.nim
@@ -1,7 +1,15 @@
 {.passL: "-lnotcurses-core".}
 
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  {.push raises: [].}
+else:
+  {.push raises: [Defect].}
+
+import ./abi/impl as abi_impl
 import ./api/impl
 
-export impl except setNcInit, setNcCoreInit
+export impl
 
-setNcCoreInit()
+proc init*(T: type Notcurses, options = Options.init, file = stdout,
+    addExitProc = true): T =
+  T.init(notcurses_core_init, options, file, addExitProc)

--- a/notcurses/direct.nim
+++ b/notcurses/direct.nim
@@ -1,7 +1,15 @@
 {.passL: "-lnotcurses -lnotcurses-core".}
 
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  {.push raises: [].}
+else:
+  {.push raises: [Defect].}
+
+import ./abi/direct/impl as abi_impl
 import ./api/direct/impl
 
-export impl except setNcdInit, setNcdCoreInit
+export impl
 
-setNcdInit()
+proc init*(T: type NotcursesDirect, options = Options.init, file = stdout,
+    addExitProc = true): T =
+  T.init(ncdirect_init, options, file, addExitProc)

--- a/notcurses/direct/core.nim
+++ b/notcurses/direct/core.nim
@@ -1,7 +1,15 @@
 {.passL: "-lnotcurses-core".}
 
+when (NimMajor, NimMinor, NimPatch) >= (1, 4, 0):
+  {.push raises: [].}
+else:
+  {.push raises: [Defect].}
+
+import ../abi/direct/impl as abi_impl
 import ../api/direct/impl
 
-export impl except setNcdInit, setNcdCoreInit
+export impl
 
-setNcdCoreInit()
+proc init*(T: type NotcursesDirect, options = Options.init, file = stdout,
+    addExitProc = true): T =
+  T.init(ncdirect_core_init, options, file, addExitProc)

--- a/tests/notcurses/test_abi.nim
+++ b/tests/notcurses/test_abi.nim
@@ -1,10 +1,11 @@
 import std/macros
 import pkg/unittest2
 import notcurses/abi
+import notcurses/abi/direct
 import ./helpers/ncseqs
 
 when not defined(windows):
-  suite "ABI tests":
+  suite "ABI":
     setup:
       let flags = NCOPTION_CLI_MODE or NCOPTION_DRAIN_INPUT or NCOPTION_SUPPRESS_BANNERS
       var opts = notcurses_options(flags: flags)
@@ -13,6 +14,22 @@ when not defined(windows):
 
     teardown:
       if notcurses_stop(nc) < 0: raise (ref Defect)(msg: "Notcurses failed to stop")
+
+    test "init then stop":
+      check: true
+
+    test "init then stop again":
+      check: true
+
+  suite "ABI Direct mode":
+    setup:
+      let
+        flags = NCDIRECT_OPTION_DRAIN_INPUT
+        ncd = ncdirect_init(nil, stdout, flags)
+      if isNil ncd: raise (ref Defect)(msg: "Direct mode failed to initialize")
+
+    teardown:
+      if ncdirect_stop(ncd) < 0: raise (ref Defect)(msg: "Direct mode failed to stop")
 
     test "init then stop":
       check: true
@@ -68,6 +85,10 @@ macro compareW(names: static openArray[string]): untyped =
           `wa_impc_puaw`[][j] == `wa`[j]
   # debugEcho toStrLit(result)
 
-suite "ABI tests (no init)":
+suite "ABI (no init)":
   test "compare importc'd wide strings with constants":
     compareW ncWideSeqsNames
+
+suite "ABI Direct mode (no init)":
+  test "should write some tests":
+    check: true

--- a/tests/notcurses/test_api.nim
+++ b/tests/notcurses/test_api.nim
@@ -2,17 +2,36 @@ import std/macros
 import pkg/unittest2
 import notcurses
 import notcurses/abi/constants
+import notcurses/direct
 import ./helpers/ncseqs
 
 when not defined(windows):
-  suite "API tests":
+  suite "API":
     setup:
       let
-        opts = [InitOptions.CliMode, InitOptions.DrainInput, InitOptions.SuppressBanners]
+        opts = [
+          notcurses.InitOptions.CliMode,
+          notcurses.InitOptions.DrainInput,
+          notcurses.InitOptions.SuppressBanners]
         nc = Nc.init(NcOptions.init opts, addExitProc = false)
 
     teardown:
       nc.stop
+
+    test "init then stop":
+      check: true
+
+    test "init then stop again":
+      check: true
+
+  suite "API Direct mode":
+    setup:
+      let
+        opts = [direct.InitOptions.DrainInput]
+        ncd = Ncd.init(NcdOptions.init opts, addExitProc = false)
+
+    teardown:
+      ncd.stop
 
     test "init then stop":
       check: true
@@ -55,7 +74,7 @@ macro compareN(names: static openArray[string]): untyped =
         ns3 == `ns`
   # debugEcho toStrLit(result)
 
-suite "API tests (no init)":
+suite "API (no init)":
   test "compare constants converted to Nim strings <-> wide strings with statics and originals":
     compareN ncWideSeqsNames
     for cs in [NCBOXLIGHT, NCBOXHEAVY, NCBOXROUND, NCBOXDOUBLE, NCBOXASCII, NCBOXOUTER]:
@@ -67,3 +86,7 @@ suite "API tests (no init)":
       check:
         ns1.cstring == cs
         ns2.cstring == cs
+
+suite "API Direct mode (no init)":
+  test "should write some tests":
+    check: true


### PR DESCRIPTION
It needs to be possible to `import notcurses` and `import notcurses/core` in the same codebase (same is true for `import notcurses/direct` and `import notcurses/direct/core`).

For example: a library author might build on `notcurses/core`, while a user of that library may wish to use it and the multimedia facilities made available via `import notcurses`